### PR TITLE
#34 「勤務表」ページで10日-11日表記もほしい

### DIFF
--- a/src/components/WorkingTime.tsx
+++ b/src/components/WorkingTime.tsx
@@ -8,21 +8,14 @@ import {
 import { getCurrentMonthAttendanceQuery } from '@/graphql/userState'
 import { dayjs } from '@/lib/dayjs'
 import { useFormatTotalWorkingTime } from '@/hooks/useFormatTotalWorkingTime'
+import { useGetPaidDateSpan } from '@/hooks/useGetPaidDateSpan'
 
 type Props = {
   targetMonth: number
 }
 export const WorkingTime = ({ targetMonth }: Props) => {
   const formatTotalWorkingTime = useFormatTotalWorkingTime()
-  const startMonth = useMemo(() => {
-    return dayjs()
-      .month(targetMonth - 1)
-      .startOf('month')
-      .format('YYYY-MM-11')
-  }, [targetMonth])
-  const endMonth = useMemo(() => {
-    return dayjs().month(targetMonth).endOf('month').format('YYYY-MM-10')
-  }, [targetMonth])
+  const { startDate, endDate } = useGetPaidDateSpan({ targetMonth })
 
   const [{ data: currentMonthAttendance }] = useQuery<
     GetCurrentMonthAttendanceQuery,
@@ -30,8 +23,8 @@ export const WorkingTime = ({ targetMonth }: Props) => {
   >({
     query: getCurrentMonthAttendanceQuery,
     variables: {
-      start: startMonth,
-      end: endMonth,
+      start: startDate,
+      end: endDate,
     },
   })
 

--- a/src/components/WorkingTime.tsx
+++ b/src/components/WorkingTime.tsx
@@ -69,7 +69,12 @@ export const WorkingTime = ({ targetMonth }: Props) => {
       <Text as='span' fontWeight='bold'>
         {paidDate.format('YYYY')}年{paidDate.format('MM')}月
       </Text>
-      分の稼働:&nbsp;
+      分
+      <Text as='span' fontSize='sm'>
+        ({paidDate.subtract(1, 'M').format('MM/11')} ~{' '}
+        {paidDate.format('MM/10')})
+      </Text>
+      の稼働:&nbsp;
       <Text as='span' fontWeight='bold'>
         {formatTotalWorkingTime(totalWorkingTime)}
       </Text>

--- a/src/hooks/useGetPaidDateSpan.ts
+++ b/src/hooks/useGetPaidDateSpan.ts
@@ -1,0 +1,20 @@
+import dayjs from 'dayjs'
+import { useMemo } from 'react'
+
+export const useGetPaidDateSpan = ({
+  targetMonth,
+}: {
+  targetMonth: number
+}) => {
+  const startDate = useMemo(() => {
+    return dayjs()
+      .month(targetMonth - 1)
+      .startOf('month')
+      .format('YYYY-MM-11')
+  }, [targetMonth])
+  const endDate = useMemo(() => {
+    return dayjs().month(targetMonth).endOf('month').format('YYYY-MM-10')
+  }, [targetMonth])
+
+  return { startDate, endDate }
+}


### PR DESCRIPTION
https://github.com/deBroglieeeen/atd-app/issues/34

select boxで選択したら画面が切り替わるようにした。
"月基準"・”給与基準”を選べるようにした
給与基準の場合：現在の月の10日までの分の勤務表を表示。
1日になったら、先月の11日から今月の10日までが出てくる。（この辺はよく考えてない。）
<img width="167" alt="image" src="https://github.com/deBroglieeeen/atd-app/assets/68529763/a1509a66-b977-4e06-bb83-355356b594eb">


ついでに、稼働時間の表記も変えた
<img width="264" alt="image" src="https://github.com/deBroglieeeen/atd-app/assets/68529763/d37042ac-7e2e-4625-9e1f-bfb5a46410fb">
